### PR TITLE
Allow PHP 8.1

### DIFF
--- a/.github/workflows/tasks.yml
+++ b/.github/workflows/tasks.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3' ]
         typo3: [ '11', '12' ]
     steps:
       - name: Setup PHP with PECL extension

--- a/Classes/DataProcessing/RelationProcessor.php
+++ b/Classes/DataProcessing/RelationProcessor.php
@@ -13,11 +13,11 @@ use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
 
-final readonly class RelationProcessor implements DataProcessorInterface
+final class RelationProcessor implements DataProcessorInterface
 {
     public function __construct(
-        private ConnectionPool $connectionPool,
-        private ContentDataProcessor $contentDataProcessor
+        private readonly ConnectionPool $connectionPool,
+        private readonly ContentDataProcessor $contentDataProcessor
     ) {
     }
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   ],
   "type": "typo3-cms-extension",
   "require": {
-    "php": "~8.2.0 || ~8.3.0",
+    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
     "typo3/cms-core": "^11.5 || ^12.0",
     "typo3/cms-frontend": "^11.5 || ^12.0"
   },


### PR DESCRIPTION
PHP 8.1 is basically usable with TYPO3 v11/v12 and the platform requirement when kickstarting a new composer project with v12.